### PR TITLE
Fixed typo in memory_view.rs

### DIFF
--- a/lib/api/src/externals/memory_view.rs
+++ b/lib/api/src/externals/memory_view.rs
@@ -133,7 +133,7 @@ impl<'a> MemoryView<'a> {
         self.0.write(offset, data)
     }
 
-    /// Safely reads a single byte from memory at the given offset
+    /// Safely writes a single byte from memory at the given offset
     ///
     /// This method is guaranteed to be safe (from the host side) in the face of
     /// concurrent writes.


### PR DESCRIPTION
# Description
Fixed a small typo in memory_view.rs `write_u8`
